### PR TITLE
Add FastAPI app with WebSocket monitor and metrics

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+APP_NAME=MqttSimulator
+ENVIRONMENT=development

--- a/app/deps.py
+++ b/app/deps.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseSettings
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment.
+
+    References MQTT 3.1.1 \u00a73.1 CONNECT.
+    """
+
+    app_name: str = "MQTT Simulator"
+    environment: str = "development"
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+
+settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, FastAPI, WebSocket
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from .deps import Settings, settings
+
+app = FastAPI(title=settings.app_name, openapi_tags=[
+    {"name": "API"},
+    {"name": "WebSocket"},
+    {"name": "Metrics"},
+])
+
+# Placeholder routers
+api_router = APIRouter(prefix="/api", tags=["API"])
+
+
+@api_router.get("/brokers")
+async def get_brokers() -> dict[str, str]:
+    return {"detail": "broker list"}
+
+
+@api_router.get("/sensors")
+async def get_sensors() -> dict[str, str]:
+    return {"detail": "sensor list"}
+
+
+app.include_router(api_router)
+
+
+@app.websocket("/ws/monitor")
+async def monitor_ws(
+    websocket: WebSocket, settings: Settings = Depends(lambda: settings)
+) -> None:
+    await websocket.accept()
+    last = time.time()
+    count = 0
+    try:
+        while True:
+            data: Any = await websocket.receive_text()
+            now = time.time()
+            latency = now - last
+            count += 1
+            payload = {
+                "sensor_id": data,
+                "last": last,
+                "count": count,
+                "latency": latency,
+            }
+            await websocket.send_text(json.dumps(payload))
+            last = now
+    except Exception:
+        await websocket.close()
+
+
+Instrumentator().instrument(app).expose(app)


### PR DESCRIPTION
## Summary
- set up FastAPI app skeleton under `app/`
- load settings from `.env`
- add placeholder API routers
- implement `/ws/monitor` WebSocket endpoint
- expose Prometheus metrics

## Testing
- `ruff check app`
- `flake8 app`


------
https://chatgpt.com/codex/tasks/task_e_686a9ba33d9c832a897ff0b4f9d846ab