### PR TITLE
Add Vue 3 scaffold docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,15 @@
+## Install dependencies
 
+```bash
+# Create a Vue 3 project with Vite
+npm create vite@latest my-app -- --template vue
+cd my-app
+npm install
+
+# Add Vuetify and other plugins
+npm install vuetify@^3 vue-router@4 pinia vue-i18n@9
+# Vuetify plugin + Sass for preprocessing
+npm install -D @vuetify/vite-plugin sass
+```
+
+The Vuetify plugin will automatically import component styles when `autoImport` is enabled in `vite.config.ts`.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import vuetify from '@vuetify/vite-plugin'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    vuetify({ autoImport: true }) // auto-imports Vuetify styles
+  ],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add instructions for creating a Vue 3 + Vuetify project
- include a starter `vite.config.ts` with Vuetify auto-imports

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa32895fc832a855337c657a96d6d