### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run bootstrap
+        run: ./bootstrap.sh
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          pytest --cov
+      - name: Build Docker image
+        run: docker build .
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@v1
+      - name: Start services
+        run: docker compose up -d
+      - name: Stop services
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run bootstrap, tests, docker build and docker compose

## Testing
- `pytest --cov`
- `docker build -t mqtt-simulator .` *(fails: command not found)*
- `docker compose up -d` *(fails: command not found)*
- `docker compose down` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab255c274832a89f33a142ad1a744